### PR TITLE
Revert "Add fetch_message_fast using history endpoint"

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -933,15 +933,12 @@ class Messageable(metaclass=abc.ABCMeta):
         """
         return Typing(self)
 
-    @utils.deprecated('fetch_message_fast')
     async def fetch_message(self, id):
         """|coro|
 
         Retrieves a single :class:`~discord.Message` from the destination.
 
         This can only be used by bot accounts.
-
-        Prefer using :meth:`fetch_message_fast`.
 
         Parameters
         ------------
@@ -966,40 +963,6 @@ class Messageable(metaclass=abc.ABCMeta):
         channel = await self._get_channel()
         data = await self._state.http.get_message(channel.id, id)
         return self._state.create_message(channel=channel, data=data)
-
-    async def fetch_message_fast(self, id):
-        """|coro|
-
-        Retrieves a single :class:`~discord.Message` from the destination, using
-        the history endpoint.
-
-        .. versionadded:: 1.5
-
-        Parameters
-        ------------
-        id: :class:`int`
-            The message ID to look for.
-
-        Raises
-        --------
-        ~discord.NotFound
-            The specified channel was not found.
-        ~discord.Forbidden
-            You do not have permissions to get channel message history.
-        ~discord.HTTPException
-            The request to get message history failed.
-
-        Returns
-        --------
-        Optional[:class:`~discord.Message`]
-            The message asked for, or None if there is no match.
-        """
-
-        channel = await self._get_channel()
-        data = await self._state.http.logs_from(channel.id, limit=1, around=id)
-        if data and int(data[0]['id']) == id:
-            return self._state.create_message(channel=channel, data=data[0])
-        return None
 
     async def pins(self):
         """|coro|


### PR DESCRIPTION
This reverts commit a309088ae4be7c2e837e5d180822c0f9060fe86d.

A rate limited was added to this method after 5 years defeating the
purpose of it.

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
